### PR TITLE
jupyterhub 2.0.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,9 @@ build:
   # 6/2/2021: Win32 platform has unsatisfiable dependencies
   # JupyterHub officially does not support Windows,
   # see https://jupyterhub.readthedocs.io/en/stable/installation-basics.html#platform-support
-  skip: true  # [win32]
+  # This package isn't included in SOW Packages list, and there isn't configurable-http-proxy >=4.0.0 on s390x
+  skip: true  # [win32 or s390x]
+  noarch: python
   script: python -m pip install --no-deps --ignore-installed .
   entry_points:
     - jupyterhub = jupyterhub.app:main
@@ -27,24 +29,24 @@ requirements:
     - setuptools
     - wheel
   run:
-    - python
+    - python >=3.6
     - alembic >=1.4
     - async_generator >=1.9
     - certipy >=0.1.2
-    - configurable-http-proxy
+    - configurable-http-proxy >=4.0.0
     - entrypoints
     - jinja2 >=2.11.0,<3.0.0
+    - jupyter_telemetry >=0.1.0
     - oauthlib >=3.0
-    - pamela  # [not win]
+    - pamela
     - prometheus_client >=0.4.0
-    - psutil  # [win]
+    - psutil
     - pycurl
     - python-dateutil
     - requests
     - sqlalchemy >=1.1
     - tornado >=5.1
     - traitlets >=4.3.2
-    - jupyter_telemetry >=0.1.0
 
 test:
   imports:
@@ -62,6 +64,10 @@ test:
     - python -m jupyterhub --help-all
     - jupyterhub -h
     - configurable-http-proxy -h
+    - test -f $PREFIX/share/jupyterhub/templates/page.html
+    - test -f $PREFIX/share/jupyterhub/static/components/jquery/dist/jquery.min.js
+    - test -f $PREFIX/share/jupyterhub/static/css/style.min.css
+    - test -f $PREFIX/share/jupyterhub/static/js/home.js
 
 about:
   home: https://github.com/jupyterhub/jupyterhub

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,10 +11,10 @@ source:
 
 build:
   number: 0
-  # 6/2/2021: Win32 platform has unsatisfiable dependencies
+  # 2021/6/2: Win32 platform has unsatisfiable dependencies
   # JupyterHub officially does not support Windows,
   # see https://jupyterhub.readthedocs.io/en/stable/installation-basics.html#platform-support
-  # This package isn't included in SOW Packages list, and there isn't configurable-http-proxy >=4.0.0 on s390x
+  # 2021/12/15: This package isn't included in SOW Packages list, and there isn't configurable-http-proxy >=4.0.0 on s390x
   skip: true  # [win32 or s390x]
   noarch: python
   script: python -m pip install --no-deps --ignore-installed .
@@ -35,12 +35,13 @@ requirements:
     - certipy >=0.1.2
     - configurable-http-proxy >=4.0.0
     - entrypoints
-    - jinja2 >=2.11.0,<3.0.0
+    - jinja2 >=2.11.0
     - jupyter_telemetry >=0.1.0
     - oauthlib >=3.0
+    - packaging
     - pamela
     - prometheus_client >=0.4.0
-    - psutil
+    - psutil >=5.6.5
     - pycurl
     - python-dateutil
     - requests

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.4.2" %}
+{% set version = "2.0.0" %}
 
 package:
   name: jupyterhub
@@ -7,7 +7,7 @@ package:
 source:
   fn: jupyterhub-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/j/jupyterhub/jupyterhub-{{ version }}.tar.gz
-  sha256: d72908b3063fed1d35a3aa793c4a7ded2c8c4016b38e0135b33af0be49a8fc21
+  sha256: 1fcb312140c4a13aabf617cf1a356025401e121648940d1c683a6ee3a3809579
 
 build:
   number: 0


### PR DESCRIPTION
Update jupyterhub to 2.0.0

Version change: bump version number from 1.4.2 to 2.0.0 (Major version bump!)
Bug Tracker: new open issues https://github.com/jupyterhub/jupyterhub/issues
Upstream setup.py:  https://github.com/jupyterhub/jupyterhub/blob/2.0.0/setup.py
Upstream requirements:  https://github.com/jupyterhub/jupyterhub/blob/2.0.0/requirements.txt

The package jupyterhub is mentioned inside the packages:
 jupyterhub-ldapauthenticator | nbserverproxy 

Actions:
1. Change architecture to `noarch: python`
2. Skip on `s390x` as it's not in the SOW Packages list and there isn't `configurable-http-proxy >=4.0.0` on s390x
3. Update run dependencies and remove preprocess-selectors
4. Add new test commands:
```
    - test -f $PREFIX/share/jupyterhub/templates/page.html
    - test -f $PREFIX/share/jupyterhub/static/components/jquery/dist/jquery.min.js
    - test -f $PREFIX/share/jupyterhub/static/css/style.min.css
    - test -f $PREFIX/share/jupyterhub/static/js/home.js
```

Result:
- all-succeeded


Tested it by running: 
1. `conda create -n __test_jupyterhub c3i_test2::jupyterhub`
2. `jupyterhub`

We should test it as a GUI